### PR TITLE
Actually fix crate name

### DIFF
--- a/src/k_macros.rs
+++ b/src/k_macros.rs
@@ -25,7 +25,7 @@ macro_rules! map {
 /// generate this implementation for us, as such:
 ///
 /// ```
-/// use pba_qualifier::impl_get;
+/// use pba_qualifier_exam::impl_get;
 /// impl_get! {
 /// 	// implements `Get<u32>` for `struct Six`
 /// 	Six: u32 = 6;

--- a/src/m_builder.rs
+++ b/src/m_builder.rs
@@ -23,7 +23,7 @@ use crate::e_common_traits::Employee;
 /// ## Example
 ///
 /// ```
-/// # use pba_qualifier::m_builder::EmployeeBuilder;
+/// # use pba_qualifier_exam::m_builder::EmployeeBuilder;
 ///
 /// # fn main() {
 /// let success = EmployeeBuilder::default().name("John".to_string()).uid(42).build();
@@ -117,7 +117,7 @@ pub struct UnIdentified;
 /// ## Example
 ///
 /// ```
-/// use pba_qualifier::m_builder::TypedEmployeeBuilder;
+/// use pba_qualifier_exam::m_builder::TypedEmployeeBuilder;
 ///
 /// # fn main() {
 /// // This is not a result anymore, because we guarantee at compile time that it has name and uid.
@@ -132,7 +132,7 @@ pub struct UnIdentified;
 /// This code will simply fail to compile:
 ///
 /// ```compile_fail
-/// use pba_qualifier::m_builder::TypedEmployeeBuilder;
+/// use pba_qualifier_exam::m_builder::TypedEmployeeBuilder;
 ///
 /// # fn main() {
 /// 	let success = TypedEmployeeBuilder::default().uid(42).build();


### PR DESCRIPTION
#2  was close ;) 

resolves `cargo t --doc` failures out of the box. 