### PR TITLE
Fix: Referring to `match` Keyword not `match!` Macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 
 [dependencies]
 # There should be NO external additions here, per the honor code.
-# If you want or need to create a local dependancy, you may do so.
+# If you want or need to create a local dependency, you may do so.

--- a/src/d_pattern_matching.rs
+++ b/src/d_pattern_matching.rs
@@ -2,7 +2,7 @@
 //! statement of the `matches!()` macro, if you feel like having an "1-liner".
 //!
 //! You can try and write them imperatively at first as well, but at the end of the day, we want you
-//! to write them using the `match!` or `matches!`.
+//! to write them using the `match` keyword or the `matches!` macro.
 
 /// Returns true if the last two strings in the vector start with `PBA`.
 pub fn match_1(input: Vec<String>) -> bool {


### PR DESCRIPTION
removes `!` after match, as it's referring to the match keyword instead of a macro. A `match!` does not exists, AFAIK.

cc @pandres95 