### PR TITLE
Removes misleading task for a procedural `derive` macro

### DIFF
--- a/src/i_extension_traits.rs
+++ b/src/i_extension_traits.rs
@@ -57,21 +57,6 @@ impl OutcomeCount for Vec<Outcome> {
 	}
 }
 
-// Now we can call these functions directly on `Vec<Outcome>`.
-
-// But all of that is a lot of boilerplate. Wouldn't it be nice to have a `derive` macro that
-// exactly does this, on any enum?
-//
-// In that case, for any `enum Foo { X, Y, .. }`, `#[derive(CountOf)]` would generate a trait
-// `CountOfFoo`, with functions named `fn x_count`, `fn y_count` etc. Finally, it would implement
-// `CountOfFoo` for `Vec<Foo>`.
-//
-// And heck, you could then easily implement it for other collections of `Foo`, such as
-// `HashMap<_, Foo>` etc.
-
-// This problem does NOT require you to implement such a macro. Perhaps you will encounter that
-// macro problem somewhere in the future.
-
 /// This function is not graded. It is just for collecting feedback.
 /// On a scale from 0 - 255, with zero being extremely easy and 255 being extremely hard,
 /// how hard did you find this section of the exam.

--- a/src/i_extension_traits.rs
+++ b/src/i_extension_traits.rs
@@ -57,6 +57,8 @@ impl OutcomeCount for Vec<Outcome> {
 	}
 }
 
+// Now we can call these functions directly on `Vec<Outcome>`.
+
 /// This function is not graded. It is just for collecting feedback.
 /// On a scale from 0 - 255, with zero being extremely easy and 255 being extremely hard,
 /// how hard did you find this section of the exam.


### PR DESCRIPTION
While doing the exam I was quite confused if I should do the removed task or not. It just with the latest patch got a clarifying statement at the end of it:

```
// This problem does NOT require you to implement such a macro. Perhaps you will encounter that
// macro problem somewhere in the future.
```

All in all I get the hint to the procedural macro but I think it's just confusing and not adding to much of a benefit. After such an exam the ignited curiosity about rust will lead naturally to learning more about procedural macros.


Furthermore, even if a examinee wants to implement it in the exam crate it's conflicting to the code of honor. Procedural macros should be defined in it's own crate and code of honor disallows any external dependencies. Also I guess not using `syn` and `quote` crates makes it quite the challenge.