### PR TITLE
Added comments to prevent complains from the compiler

### DIFF
--- a/src/k_macros.rs
+++ b/src/k_macros.rs
@@ -25,6 +25,7 @@ macro_rules! map {
 /// generate this implementation for us, as such:
 ///
 /// ```
+/// use pba_qualifier_exam::k_macros::Get;
 /// use pba_qualifier_exam::impl_get;
 /// impl_get! {
 /// 	// implements `Get<u32>` for `struct Six`

--- a/src/m_builder.rs
+++ b/src/m_builder.rs
@@ -121,6 +121,7 @@ pub struct UnIdentified;
 ///
 /// # fn main() {
 /// // This is not a result anymore, because we guarantee at compile time that it has name and uid.
+///     use pba_qualifier_exam::m_builder::TypedEmployeeBuilder;
 /// 	let employee =
 /// 	TypedEmployeeBuilder::default().name("John".to_string()).uid(42).wage(77).build();
 /// assert_eq!(employee.name, "John");


### PR DESCRIPTION
Once the students start writing code in k_macros.rs, my compiler begins to generate errors. I believe that those comments are causing the issue.